### PR TITLE
Replaced dependency on deprecated web-encodings package with urlencoded.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 dist/
 *.swp
+
+# Cabal Sandbox files
+.cabal-sandbox
+cabal.sandbox.config

--- a/Network/Shpider.hs
+++ b/Network/Shpider.hs
@@ -75,7 +75,6 @@ import           Network.Shpider.State
 import           Network.Shpider.URL
 import           System.Directory
 import           Text.HTML.TagSoup
-import           Text.HTML.TagSoup
 import           Text.Regex.Posix
 
 -- | if `keepTrack` has been set, then haveVisited will return `True` if the given URL has been visited.
@@ -265,12 +264,6 @@ sendForm form = do
                     postURL absAddr $ M.toList $ inputs form          
          )
          mabsAddr
-   
--- encodeUrl = undefined
-
--- toPostField :: (String, String) -> String
--- toPostField ( name , value ) =
---    encodeUrl name ++ "=" ++ encodeUrl value
 
 -- | Return the links on the current page.
 currentLinks :: Shpider [ Link ]
@@ -344,7 +337,7 @@ postURL url fields = withThrottle $ do
    cachedRequest url (opts shpider)
    where
     opts sh =
-      [ CurlPostFields (map (export . urlEncode) fields)
+      [ CurlPostFields $ map (export . urlEncode) fields
       , CurlPost True
       ] ++ curlOpts sh
 

--- a/Network/Shpider.hs
+++ b/Network/Shpider.hs
@@ -65,6 +65,7 @@ import           Control.Monad.State
 import qualified Data.Map                as M
 import           Data.Maybe
 import           Data.Time
+import           Data.URLEncoded         (export, urlEncode)
 import           Network.Curl
 import           Network.Shpider.Code
 import           Network.Shpider.Forms
@@ -76,8 +77,6 @@ import           System.Directory
 import           Text.HTML.TagSoup
 import           Text.HTML.TagSoup
 import           Text.Regex.Posix
-import           Web.Encodings
-
 
 -- | if `keepTrack` has been set, then haveVisited will return `True` if the given URL has been visited.
 haveVisited :: String -> Shpider Bool
@@ -267,8 +266,11 @@ sendForm form = do
          )
          mabsAddr
    
-toPostField ( name , value ) =
-   encodeUrl name ++ "=" ++ encodeUrl value
+-- encodeUrl = undefined
+
+-- toPostField :: (String, String) -> String
+-- toPostField ( name , value ) =
+--    encodeUrl name ++ "=" ++ encodeUrl value
 
 -- | Return the links on the current page.
 currentLinks :: Shpider [ Link ]
@@ -342,7 +344,7 @@ postURL url fields = withThrottle $ do
    cachedRequest url (opts shpider)
    where
     opts sh =
-      [ CurlPostFields (map toPostField fields)
+      [ CurlPostFields (map (export . urlEncode) fields)
       , CurlPost True
       ] ++ curlOpts sh
 

--- a/shpider.cabal
+++ b/shpider.cabal
@@ -1,5 +1,5 @@
 Name:               shpider 
-Version:            0.2.2.0
+Version:            0.3.0.0
 Synopsis:           Web automation library in Haskell.
 Description:
     Shpider is a web automation library for Haskell.   It allows you to quickly
@@ -47,7 +47,7 @@ Library
     , time 
     , bytestring
     , transformers
-    , web-encodings
+    , urlencoded
    Exposed-modules: Network.Shpider.URL
                     Network.Shpider.Code
                     Network.Shpider.State


### PR DESCRIPTION
The web-encodings package is deprecated and doesn't build on GHC 7.8, so I replaced it with urlencoded, which seems a bit nicer anyhow. I also bumped the version number to 0.3.0.0. 
